### PR TITLE
WordPress keys, salts and Capital P

### DIFF
--- a/Ubuntu-14.04/cms/wordpress.sh
+++ b/Ubuntu-14.04/cms/wordpress.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 #
-# Wordpress Setup Script
+# WordPress Setup Script
 #
-# This script will install and configure Wordpress on
+# This script will install and configure WordPress on
 # an Ubuntu 14.04 droplet
 export DEBIAN_FRONTEND=noninteractive;
 
@@ -22,7 +22,7 @@ apt-get -y upgrade;
 # Install Apache/MySQL
 apt-get -y install apache2 php5 php5-mysql mysql-server mysql-client unzip;
 
-# Download and uncompress Wordpress
+# Download and uncompress WordPress
 wget https://wordpress.org/latest.zip -O /tmp/wordpress.zip;
 cd /tmp/;
 unzip /tmp/wordpress.zip;
@@ -32,11 +32,16 @@ unzip /tmp/wordpress.zip;
 /usr/bin/mysql -uroot -p$rootmysqlpass -e "CREATE USER wordpress@localhost IDENTIFIED BY '"$wpmysqlpass"'";
 /usr/bin/mysql -uroot -p$rootmysqlpass -e "GRANT ALL PRIVILEGES ON wordpress.* TO wordpress@localhost";
 
-# Configure Wordpress
+# Configure WordPress
 cp /tmp/wordpress/wp-config-sample.php /tmp/wordpress/wp-config.php;
 sed -i "s/'DB_NAME', 'database_name_here'/'DB_NAME', 'wordpress'/g" /tmp/wordpress/wp-config.php;
 sed -i "s/'DB_USER', 'username_here'/'DB_USER', 'wordpress'/g" /tmp/wordpress/wp-config.php;
 sed -i "s/'DB_PASSWORD', 'password_here'/'DB_PASSWORD', '$wpmysqlpass'/g" /tmp/wordpress/wp-config.php;
+for i in `seq 1 8`
+do
+wp_salt=$(</dev/urandom tr -dc 'a-zA-Z0-9!@#$%^&*()\-_ []{}<>~`+=,.;:/?|' | head -c 64 | sed -e 's/[\/&]/\\&/g');
+sed -i "0,/put your unique phrase here/s/put your unique phrase here/$wp_salt/" /tmp/wordpress/wp-config.php;
+done
 cp -Rf /tmp/wordpress/* /var/www/html/.;
 rm -f /var/www/html/index.html;
 chown -Rf www-data:www-data /var/www/html;


### PR DESCRIPTION
The `wp-config.php` file defines constants for keys and salts which are used to hash passwords, nonces and cookies.

<https://codex.wordpress.org/Editing_wp-config.php#Security_Keys>

The set used in the `tr` command was taken from [`wp_generate_password()`](https://codex.wordpress.org/Function_Reference/wp_generate_password):

```
tr -dc 'a-zA-Z0-9!@#$%^&*()\-_ []{}<>~`+=,.;:/?|'
```

The backslash before the hyphen (`\-`) was used to escape it as `tr` confuses it with the hyphen used for ranges like `a-z` and `0-9`.

The following pattern escapes slashes and ampersands in the generated string to prevent them from messing up the next `sed`:

```
sed -e 's/[\/&]/\\&/g'
```

Capital P for Word**P**ress for the comments :)
<http://wptavern.com/do-you-mistrust-a-company-that-misspells-wordpress>
<http://capitalp.org/>