### PR TITLE
Change Host Name in Ubuntu 14.04

### DIFF
--- a/Ubuntu-14.04/change-hostn/README.md
+++ b/Ubuntu-14.04/change-hostn/README.md
@@ -1,0 +1,20 @@
+change-hostn.sh 
+---------------
+
+## This script: 
+
+* assigns user input to the variable `newhostn`
+* displays current hostname 
+* displays change to be made 
+* assigns `newhostn` to both `/etc/hosts` and `/etc/hostname`
+* makes change permanent upon reboot 
+
+in Ubuntu 14.04. 
+
+### History 
+
+2015-12-24 Initial commit 
+
+### License  
+
+MIT license. 

--- a/Ubuntu-14.04/change-hostn/change.hostn.sh
+++ b/Ubuntu-14.04/change-hostn/change.hostn.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+#Change droplet's current hostname to user defined hostname
+#Ubuntu 14.04 
+
+#Assign user input to $newhostn 
+newhostn="<%newhostn%>"
+
+#Assign current hostname to $hostn
+hostn=$(cat /etc/hostname)
+
+#Display existing hostname
+echo "Existing hostname is $hostn"
+
+#Display change to be made
+echo "New hostname will be $newhostn" 
+
+#Change hostname in /etc/hosts & /etc/hostname
+sed -i "s/$hostn/$newhostn/g" /etc/hosts
+sed -i "s/$hostn/$newhostn/g" /etc/hostname
+
+#Make changes to droplet permanent 
+reboot

--- a/Ubuntu-14.04/change-hostn/change.hostn.simple.yml
+++ b/Ubuntu-14.04/change-hostn/change.hostn.simple.yml
@@ -1,0 +1,3 @@
+#cloud-config 
+hostname: 
+  - hostname: hostname 

--- a/Ubuntu-14.04/change-hostn/change.hostn.yml
+++ b/Ubuntu-14.04/change-hostn/change.hostn.yml
@@ -1,0 +1,10 @@
+#cloud-config 
+runcmd: 
+  - newhostn="<%newhostn%>"
+  - hostn=$(cat /etc/hostname)
+  - echo "Exisitng hostname is $hostn"
+  - echo "New hostname will be $newhostn"
+  - sed -i "s/$hostn/$newhostn/g" /etc/hosts
+  - sed -i "s/$hostn/$newhostn/g" /etc/hostname
+power_state: 
+  mode: reboot 


### PR DESCRIPTION
From time to time I've found it helpful to change a droplet's `hostname` via a shell script. Included here is a: 

* a modified version of that script (change.hostn.sh) which should work with `cloud-config`;
* an initial README for this script;
* two versions of a `yml` script which could, with some feedback, accomplish the same as the .sh script. 

I'd be happy to make any necessary changes, as well as script out the same for other distros. 

Cheers.  
  