### PR TITLE
Change PHP-FPM User and Group

### DIFF
--- a/CentOS-7/cms/wordpress-nginx.yml
+++ b/CentOS-7/cms/wordpress-nginx.yml
@@ -90,6 +90,8 @@ runcmd:
   - mkdir -p /var/www/html
   - sed -ie "s/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/" /etc/php.ini
   - sed -ie "s|listen = 127.0.0.1:9000|listen = /var/run/php-fpm/php-fpm.sock|" /etc/php-fpm.d/www.conf
+  - sed -ie "s|user = apache|user = nginx|" /etc/php-fpm.d/www.conf
+  - sed -ie "s|group = apache|group = nginx|" /etc/php-fpm.d/www.conf
   - cp -Rf /tmp/wordpress/* /var/www/html/.
   - chown -Rf nginx.nginx /var/www/html/*
   - rm -f /var/www/html/index.html


### PR DESCRIPTION
Also would recommend changing the process manager to 'ondemand' rather than static. That's up to you whether or not you want to add that. This fixes the permission issues with nginx and wordpress.