### PR TITLE
Flush privileges operation.Mariadb enable

### DIFF
--- a/CentOS-7/web-servers/lemp.yml
+++ b/CentOS-7/web-servers/lemp.yml
@@ -42,6 +42,9 @@ write_files:
 runcmd:
   - rpm -Uvh http://nginx.org/packages/centos/7/noarch/RPMS/nginx-release-centos-7-0.el7.ngx.noarch.rpm
   - yum -y install nginx php-fpm php-mysql mariadb-server mariadb
+  - systemctl enable mariadb
+  - systemctl restart mariadb
+  - mysql_secure_installation
   - mkdir -p /var/www/html
   - cp /usr/share/nginx/html/index.html /var/www/html/
   - sed -i -e "s/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/" /etc/php.ini

--- a/Ubuntu-16.04/cms/wordpress.sh
+++ b/Ubuntu-16.04/cms/wordpress.sh
@@ -31,6 +31,7 @@ unzip /tmp/wordpress.zip;
 /usr/bin/mysqladmin -u root -h localhost password $rootmysqlpass;
 /usr/bin/mysql -uroot -p$rootmysqlpass -e "CREATE USER wordpress@localhost IDENTIFIED BY '"$wpmysqlpass"'";
 /usr/bin/mysql -uroot -p$rootmysqlpass -e "GRANT ALL PRIVILEGES ON wordpress.* TO wordpress@localhost";
+/usr/bin/mysql -u root -p$rootmysqlpass -e "FLUSH PRIVILEGES";
 
 # Configure WordPress
 cp /tmp/wordpress/wp-config-sample.php /tmp/wordpress/wp-config.php;

--- a/Ubuntu-16.04/cms/wordpress.sh
+++ b/Ubuntu-16.04/cms/wordpress.sh
@@ -20,7 +20,8 @@ apt-get update;
 apt-get -y upgrade;
 
 # Install Apache/MySQL
-apt-get -y install apache2 php php-mysql libapache2-mod-php7.0 php7.0-mysql php7.0-curl php7.0-zip php7.0-json mysql-server mysql-client unzip wget;
+apt-get -y install apache2 php php-mysql libapache2-mod-php7.0 php7.0-mysql php7.0-curl php7.0-zip php7.0-json mysql-server mysql-client unzip  php5-gd
+wget ;
 
 # Download and uncompress WordPress
 wget https://wordpress.org/latest.zip -O /tmp/wordpress.zip;


### PR DESCRIPTION
I would like to suggest  this changes to Reload mysql server and is necesary to perform a flush-privileges operation.
The Second change is enabling and starting Mariadb that was missed in #53. 
I would like to set the label **hacktoberfest**  to this pull request :smile:. During this week I will be reviewing all the scripts using DO :smiley: 
