### PR TITLE
Install php7.0-xml package on LAMP, LEMP and WordPress Apps

### DIFF
--- a/Ubuntu-16.04/cms/wordpress.sh
+++ b/Ubuntu-16.04/cms/wordpress.sh
@@ -20,7 +20,7 @@ apt-get update;
 apt-get -y upgrade;
 
 # Install Apache/MySQL
-apt-get -y install apache2 php php-mysql libapache2-mod-php7.0 php7.0-mysql php7.0-curl php7.0-zip php7.0-json mysql-server mysql-client unzip wget;
+apt-get -y install apache2 php php-mysql libapache2-mod-php7.0 php7.0-mysql php7.0-curl php7.0-zip php7.0-json php7.0-xml mysql-server mysql-client unzip wget;
 
 # Download and uncompress WordPress
 wget https://wordpress.org/latest.zip -O /tmp/wordpress.zip;

--- a/Ubuntu-16.04/web-servers/lamp.yml
+++ b/Ubuntu-16.04/web-servers/lamp.yml
@@ -8,6 +8,7 @@ packages:
   - php7.0-mcrypt
   - php7.0-gd
   - php7.0-curl
+  - php7.0-xml
 write_files:
   - path: /var/www/html/info.php
     content: |

--- a/Ubuntu-16.04/web-servers/lemp.yml
+++ b/Ubuntu-16.04/web-servers/lemp.yml
@@ -8,6 +8,7 @@ packages:
   - php7.0-mcrypt
   - php7.0-gd
   - php7.0-curl
+  - php7.0-xml
 write_files:
   - path: /etc/nginx/sites-available/default
     content: |


### PR DESCRIPTION
The PHP5 packages available on Ubuntu 14.04 installed the modules needed for XML functions and classes like `simplexml_load_file`. These functions are required by several WordPress plugins and has to be separately installed on PHP7.
