### PR TITLE
since systemd is enabled on ubuntu 16.04

### DIFF
--- a/Ubuntu-16.04/cms/wordpress.sh
+++ b/Ubuntu-16.04/cms/wordpress.sh
@@ -48,4 +48,4 @@ cp -Rf /tmp/wordpress/* /var/www/html/.;
 rm -f /var/www/html/index.html;
 chown -Rf www-data:www-data /var/www/html;
 a2enmod rewrite;
-service apache2 restart;
+systemctl restart apache2;


### PR DESCRIPTION
since systemd is enabled on ubuntu 16.04 the command 'service apache2 restart' becomes 'systemctl restart apache2'