### PR TITLE
Added line to stop error with common TLS Error

### DIFF
--- a/Ubuntu-14.04/network/open-vpn.yml
+++ b/Ubuntu-14.04/network/open-vpn.yml
@@ -49,7 +49,7 @@ runcmd:
   - sed -i -e 's/ca ca.crt//' /etc/openvpn/easy-rsa/keys/client.ovpn
   - sed -i -e 's/cert client.crt//' /etc/openvpn/easy-rsa/keys/client.ovpn
   - sed -i -e 's/key client.key//' /etc/openvpn/easy-rsa/keys/client.ovpn
-  - sed -i -e 's/tls-auth ta.key 0//' /etc/openvpn/easy-rsa/keys/client.ovpn
+  - sed -i -e 's/tls-auth ta.key 1//' /etc/openvpn/easy-rsa/keys/client.ovpn
   - echo "<ca>" >> /etc/openvpn/easy-rsa/keys/client.ovpn
   - cat /etc/openvpn/ca.crt >> /etc/openvpn/easy-rsa/keys/client.ovpn
   - echo "</ca>" >> /etc/openvpn/easy-rsa/keys/client.ovpn

--- a/Ubuntu-14.04/network/open-vpn.yml
+++ b/Ubuntu-14.04/network/open-vpn.yml
@@ -49,6 +49,7 @@ runcmd:
   - sed -i -e 's/ca ca.crt//' /etc/openvpn/easy-rsa/keys/client.ovpn
   - sed -i -e 's/cert client.crt//' /etc/openvpn/easy-rsa/keys/client.ovpn
   - sed -i -e 's/key client.key//' /etc/openvpn/easy-rsa/keys/client.ovpn
+  - sed -i -e 's/tls-auth ta.key 0//' /etc/openvpn/easy-rsa/keys/client.ovpn
   - echo "<ca>" >> /etc/openvpn/easy-rsa/keys/client.ovpn
   - cat /etc/openvpn/ca.crt >> /etc/openvpn/easy-rsa/keys/client.ovpn
   - echo "</ca>" >> /etc/openvpn/easy-rsa/keys/client.ovpn


### PR DESCRIPTION
This error occurs without removing the TLS line, as it cannot find the `ta.key` file
```
<date> TLS Error: TLS key negotiation failed to occur within 60 seconds (check your network connectivity)
<date> TLS Error: TLS handshake failed
<date> SIGUSR1[soft,tls-error] received, process restarting
<date> MANAGEMENT: >STATE:1499104696,RECONNECTING,tls-error,,,,,
```